### PR TITLE
ULID support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/snamber/reformat-time
 
 go 1.17
 
-require github.com/integrii/flaggy v1.4.4
+require (
+	github.com/google/uuid v1.3.1
+	github.com/integrii/flaggy v1.4.4
+	github.com/oklog/ulid/v2 v2.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/integrii/flaggy v1.4.4 h1:8fGyiC14o0kxhTqm2VBoN19fDKPZsKipP7yggreTMDc=
 github.com/integrii/flaggy v1.4.4/go.mod h1:tnTxHeTJbah0gQ6/K0RW0J7fMUBk9MCF5blhm43LNpI=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/integrii/flaggy"
+	"github.com/oklog/ulid/v2"
 	"log"
 	"math"
 	"os"
@@ -14,18 +16,19 @@ import (
 func main() {
 
 	var (
-		rfc3339, rfc3339utc, unix, milli, float bool
+		rfc3339, rfc3339utc, unix, milli, float, ulid bool
 	)
 	flaggy.Bool(&rfc3339utc, "", "rfc3339-utc", "Format time as RFC 3339 UTC (default)")
 	flaggy.Bool(&rfc3339, "r", "rfc3339", "Format time as RFC 3339")
 	flaggy.Bool(&unix, "u", "unix", "Format time as unix time")
 	flaggy.Bool(&milli, "m", "unix-milli", "Format time as unix milli")
 	flaggy.Bool(&float, "f", "unix-float", "Format time as unix float")
+	flaggy.Bool(&ulid, "id", "uuid", "Format time as UUID (ULID)")
 	flaggy.SetDescription("A tiny convenience tool to convert time formats.\n\n  Example:\n    reformat-time -u -- \"$(date)\"")
 	flaggy.Parse()
 
 	// Set default
-	if !(rfc3339 || rfc3339utc || unix || milli || float) {
+	if !(rfc3339 || rfc3339utc || unix || milli || float || ulid) {
 		rfc3339utc = true
 	}
 
@@ -47,6 +50,8 @@ func main() {
 		parsed = p
 	} else if p, err := parseFloat(input); err == nil {
 		parsed = p
+	} else if p, err := parseUUID(input); err == nil {
+		parsed = p
 	} else {
 		log.Fatalf("Failed to parse %s\n", input)
 	}
@@ -66,6 +71,13 @@ func main() {
 	}
 	if float {
 		fmt.Printf("Float: %f\n", float64(parsed.UnixNano())/1e9)
+	}
+	if ulid {
+		converted, err := convertToUUID(parsed)
+		if err != nil {
+			log.Fatalf("Failed to convert parsed timestamp to a ULID: %s\n", parsed)
+		}
+		fmt.Printf("ULID: %s\n", converted)
 	}
 }
 
@@ -99,4 +111,57 @@ func parseFloat(input string) (time.Time, error) {
 	remainder := f - floor
 	nano := remainder * 1e9
 	return time.Unix(int64(floor), int64(nano)), nil
+}
+
+func parseUUID(input string) (time.Time, error) {
+	id, err := uuid.Parse(input)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return ulid.Time(uuid2ulid(id).Time()), nil
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// convertToUUID generates a new ulid.ULID for a given timestamp with entropy bits set to zero and returns it as UUID
+func convertToUUID(time time.Time) (uuid.UUID, error) {
+	ul, err := ulid.New(ulid.Timestamp(time), zeroReader{})
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("failed to create new ulid: %w", err)
+	}
+	return ulid2uuid(ul), nil
+
+}
+
+// ulid2uuid converts a ulid.ULID to a uuid.UUID
+func ulid2uuid(ulid ulid.ULID) uuid.UUID {
+	bt, err := ulid.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	uu, err := uuid.FromBytes(bt)
+	if err != nil {
+		panic(err)
+	}
+	return uu
+}
+
+// uuid2ulid converts a uuid.UUID to a ulid.ULID
+func uuid2ulid(uuid uuid.UUID) (ulid ulid.ULID) {
+	bt, err := uuid.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	err = ulid.UnmarshalBinary(bt)
+	if err != nil {
+		panic(err)
+	}
+	return ulid
 }

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Flags:
 -u --unix          Format time as unix time
 -m --unix-milli    Format time as unix milli
 -f --unix-float    Format time as unix float
+-id --uuid         Format time as UUID (ULID)
 ```
 
 `reformat-time` currently parses:
@@ -23,3 +24,4 @@ Flags:
 - Unix timestamp
 - Unix millisecond timestamp
 - Unix float timestamp
+- [ULID](https://github.com/ulid/spec) UUID (Universally Unique Lexicographically Sortable Identifier)


### PR DESCRIPTION
Adds support for conversion to and from ULID:

```
> reformat-time -- 017e6b09-ebbe-08cc-1a37-66b2e00a98e5
FRC3339Nano UTC: 2022-01-18T02:35:19.358Z
```

```
> reformat-time -id -- 2022-01-18T02:35:19.358Z
ULID: 017e6b09-ebbe-0000-0000-000000000000
```